### PR TITLE
Fix background video reset on page navigation

### DIFF
--- a/BlazorHybridApp/Components/App.razor
+++ b/BlazorHybridApp/Components/App.razor
@@ -15,6 +15,10 @@
 
 <body>
     <Routes />
+    <video id="background-video-1" class="background-video" autoplay muted preload="auto" playsinline></video>
+    <video id="background-video-2" class="background-video" autoplay muted preload="auto" playsinline></video>
+    <div id="video-info"></div>
+    <script src="js/background-video.js"></script>
     <script src="_framework/blazor.web.js"></script>
 </body>
 

--- a/BlazorHybridApp/Components/Layout/MainLayout.razor
+++ b/BlazorHybridApp/Components/Layout/MainLayout.razor
@@ -16,11 +16,6 @@
     </main>
 </div>
 
-<video id="background-video-1" class="background-video" autoplay muted preload="auto" playsinline></video>
-<video id="background-video-2" class="background-video" autoplay muted preload="auto" playsinline></video>
-<div id="video-info"></div>
-
-<script src="js/background-video.js"></script>
 
 <div id="blazor-error-ui" data-nosnippet>
     An unhandled error has occurred.

--- a/BlazorHybridApp/Components/Layout/MainLayout.razor.css
+++ b/BlazorHybridApp/Components/Layout/MainLayout.razor.css
@@ -4,31 +4,6 @@
     flex-direction: column;
 }
 
-.background-video {
-    position: fixed;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    height: 30vh;
-    width: 100%;
-    object-fit: cover;
-    pointer-events: none;
-    z-index: -1;
-    background-color: black;
-    opacity: 0;
-    transition: opacity 0.5s ease-in-out;
-}
-
-#video-info {
-    position: fixed;
-    left: 0;
-    bottom: 0;
-    padding: 0.25rem 0.5rem;
-    background: rgba(0, 0, 0, 0.5);
-    color: white;
-    font-size: 0.9rem;
-    z-index: 1;
-}
 
 main {
     flex: 1;

--- a/BlazorHybridApp/wwwroot/app.css
+++ b/BlazorHybridApp/wwwroot/app.css
@@ -69,3 +69,29 @@ h1:focus {
 .form-floating > .form-control-plaintext:focus::placeholder, .form-floating > .form-control:focus::placeholder {
     text-align: start;
 }
+
+.background-video {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    height: 30vh;
+    width: 100%;
+    object-fit: cover;
+    pointer-events: none;
+    z-index: -1;
+    background-color: black;
+    opacity: 0;
+    transition: opacity 0.5s ease-in-out;
+}
+
+#video-info {
+    position: fixed;
+    left: 0;
+    bottom: 0;
+    padding: 0.25rem 0.5rem;
+    background: rgba(0, 0, 0, 0.5);
+    color: white;
+    font-size: 0.9rem;
+    z-index: 1;
+}


### PR DESCRIPTION
## Summary
- keep background video outside layout so it isn't recreated on every navigation
- move styles for the video to `app.css`
- remove old video markup and styles from `MainLayout`

## Testing
- `dotnet build` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683a7a9305488322bbfd7a04c64196d4