### PR TITLE
Fix D3 initialization

### DIFF
--- a/BlazorHybridApp/Components/App.razor
+++ b/BlazorHybridApp/Components/App.razor
@@ -11,7 +11,9 @@
     <ImportMap />
     <link rel="icon" type="image/png" href="favicon.png" />
     <HeadOutlet />
-</head>
+    <script src="lib/d3/dist/d3.min.js"></script>
+    <script src="js/d3demo.js"></script>
+  </head>
 
 <body>
     <Routes />

--- a/BlazorHybridApp/Components/Pages/D3Demo.razor
+++ b/BlazorHybridApp/Components/Pages/D3Demo.razor
@@ -7,8 +7,6 @@
 
 <div id="d3-container"></div>
 
-<script src="lib/d3/dist/d3.min.js"></script>
-<script src="js/d3demo.js"></script>
 
 @code {
     [Inject] IJSRuntime JSRuntime { get; set; } = default!;


### PR DESCRIPTION
## Summary
- register D3 scripts in the main host page
- remove inline script tags from D3Demo page

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683adf11e1608322b679b7b3a74c57e5