### PR TITLE
Fix compile error by removing invalid namespace

### DIFF
--- a/BlazorHybridApp.Client/_Imports.razor
+++ b/BlazorHybridApp.Client/_Imports.razor
@@ -8,4 +8,3 @@
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop
 @using BlazorHybridApp.Client
-@using BlazorHybridApp.Components.Layout


### PR DESCRIPTION
## Summary
- remove BlazorHybridApp.Components.Layout from client imports

## Testing
- `dotnet run` *(fails: `bash: dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683ae476afa083228aac270024e63c68