### PR TITLE
Seed background video URLs at startup

### DIFF
--- a/BlazorHybridApp/Data/ApplicationDbContext.cs
+++ b/BlazorHybridApp/Data/ApplicationDbContext.cs
@@ -5,4 +5,5 @@ namespace BlazorHybridApp.Data;
 
 public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : IdentityDbContext<ApplicationUser>(options)
 {
+    public DbSet<BackgroundVideo> BackgroundVideos => Set<BackgroundVideo>();
 }

--- a/BlazorHybridApp/Data/BackgroundVideo.cs
+++ b/BlazorHybridApp/Data/BackgroundVideo.cs
@@ -1,0 +1,9 @@
+namespace BlazorHybridApp.Data;
+
+public class BackgroundVideo
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+    public string Url { get; set; } = string.Empty;
+    public string? Poster { get; set; }
+}

--- a/BlazorHybridApp/Data/DataSeeder.cs
+++ b/BlazorHybridApp/Data/DataSeeder.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+using BlazorHybridApp.Services;
+
+namespace BlazorHybridApp.Data;
+
+public static class DataSeeder
+{
+    public static async Task SeedBackgroundVideosAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+    {
+        using var scope = services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var client = scope.ServiceProvider.GetRequiredService<PexelsClient>();
+
+        if (await db.BackgroundVideos.AnyAsync(cancellationToken))
+            return;
+
+        var waterfallInfo = await client.GetVideoInfoAsync(6394054, cancellationToken);
+        var goatUrl = await client.GetVideoUrlAsync(30646036, cancellationToken);
+
+        db.BackgroundVideos.Add(new BackgroundVideo
+        {
+            Name = "waterfall",
+            Url = waterfallInfo.Url,
+            Poster = waterfallInfo.Poster
+        });
+
+        db.BackgroundVideos.Add(new BackgroundVideo
+        {
+            Name = "goat",
+            Url = goatUrl
+        });
+
+        await db.SaveChangesAsync(cancellationToken);
+    }
+}

--- a/BlazorHybridApp/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/BlazorHybridApp/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -86,6 +86,30 @@ namespace BlazorHybridApp.Migrations
                     b.ToTable("AspNetUsers", (string)null);
                 });
 
+            modelBuilder.Entity("BlazorHybridApp.Data.BackgroundVideo", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer");
+
+                    NpgsqlPropertyBuilderExtensions.UseIdentityByDefaultColumn(b.Property<int>("Id"));
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.Property<string>("Poster")
+                        .HasColumnType("text");
+
+                    b.Property<string>("Url")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("BackgroundVideos", (string)null);
+                });
+
             modelBuilder.Entity("Microsoft.AspNetCore.Identity.IdentityRole", b =>
                 {
                     b.Property<string>("Id")

--- a/BlazorHybridApp/Program.cs
+++ b/BlazorHybridApp/Program.cs
@@ -5,8 +5,8 @@ using Npgsql.EntityFrameworkCore.PostgreSQL;
 using BlazorHybridApp.Client.Pages;
 using BlazorHybridApp.Components;
 using BlazorHybridApp.Components.Account;
-using BlazorHybridApp.Data;
 using BlazorHybridApp.Services;
+using BlazorHybridApp.Data;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -49,6 +49,7 @@ using (var scope = app.Services.CreateScope())
 {
     var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
     db.Database.EnsureCreated();
+    DataSeeder.SeedBackgroundVideosAsync(scope.ServiceProvider).GetAwaiter().GetResult();
 }
 
 // Configure the HTTP request pipeline.
@@ -71,25 +72,25 @@ app.UseAntiforgery();
 
 app.MapStaticAssets();
 
-app.MapGet("/api/waterfall-video-info", async (PexelsClient client, CancellationToken ct) =>
+app.MapGet("/api/waterfall-video-info", async (ApplicationDbContext db, CancellationToken ct) =>
 {
-    const int videoId = 6394054;
-    var info = await client.GetVideoInfoAsync(videoId, ct);
+    var info = await db.BackgroundVideos.FirstOrDefaultAsync(v => v.Name == "waterfall", ct);
+    if (info is null) return Results.NotFound();
     return Results.Json(new { url = info.Url, poster = info.Poster });
 });
 
-app.MapGet("/api/waterfall-video-url", async (PexelsClient client, CancellationToken ct) =>
+app.MapGet("/api/waterfall-video-url", async (ApplicationDbContext db, CancellationToken ct) =>
 {
-    const int videoId = 6394054;
-    var url = await client.GetVideoUrlAsync(videoId, ct);
-    return Results.Json(new { url });
+    var info = await db.BackgroundVideos.FirstOrDefaultAsync(v => v.Name == "waterfall", ct);
+    if (info is null) return Results.NotFound();
+    return Results.Json(new { url = info.Url });
 });
 
-app.MapGet("/api/goat-video-url", async (PexelsClient client, CancellationToken ct) =>
+app.MapGet("/api/goat-video-url", async (ApplicationDbContext db, CancellationToken ct) =>
 {
-    const int videoId = 30646036;
-    var url = await client.GetVideoUrlAsync(videoId, ct);
-    return Results.Json(new { url });
+    var info = await db.BackgroundVideos.FirstOrDefaultAsync(v => v.Name == "goat", ct);
+    if (info is null) return Results.NotFound();
+    return Results.Json(new { url = info.Url });
 });
 
 app.MapPost("/api/upload-test", async (HttpContext context) =>


### PR DESCRIPTION
## Summary
- create a `BackgroundVideo` entity to hold preloaded video URLs
- add a `DataSeeder` that fetches video URLs from Pexels
- seed the database on startup
- serve cached URLs from the database in background video endpoints
- update EF snapshot for the new entity

## Testing
- `npm ci` *(fails: Exit handler never called)*

------
https://chatgpt.com/codex/tasks/task_e_683eb414f07883229f4531aa5cf818a7