### PR TITLE
Fix reset script migration removal

### DIFF
--- a/scripts/reset-db-and-migrations.sh
+++ b/scripts/reset-db-and-migrations.sh
@@ -6,11 +6,14 @@ set -e  # Exit on error
 
 $scriptdir/clear-db.sh
 
-# Remove old migrations (EF migrations live under Data/Migrations)
-if [ -d "$scriptdir/../BlazorHybridApp/Data/Migrations" ]; then
-  rm -rf "$scriptdir/../BlazorHybridApp/Data/Migrations"
-  echo "✅ Old migrations directory removed."
-fi
+# Remove old migrations (handle both legacy and current paths)
+for migdir in "$scriptdir/../BlazorHybridApp/Migrations" \
+               "$scriptdir/../BlazorHybridApp/Data/Migrations"; do
+  if [ -d "$migdir" ]; then
+    rm -rf "$migdir"
+    echo "✅ Removed migrations directory: $(basename "$migdir")"
+  fi
+done
 cd $scriptdir/../BlazorHybridApp
 # Create new migration
 dotnet ef migrations add InitialCreate


### PR DESCRIPTION
## Notes
- Updated `reset-db-and-migrations.sh` to remove existing migration folders before creating a new one. This resolves failure when the migration `InitialCreate` already exists.

## Testing
- `./scripts/reset-db-and-migrations.sh` *(fails: `psql: command not found`)*
- `dotnet build BlazorHybridApp/BlazorHybridApp.csproj -c Release` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_683eb8fa414c8322be15761878b2ec42