### PR TITLE
Add hollow text overlay on home page

### DIFF
--- a/BlazorHybridApp/Components/Pages/Home.razor.css
+++ b/BlazorHybridApp/Components/Pages/Home.razor.css
@@ -1,0 +1,19 @@
+h1 {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 6vw;
+    color: transparent;
+    -webkit-text-stroke: 2px white;
+    text-stroke: 2px white;
+    z-index: 1;
+    margin: 0;
+}
+
+/* Ensure the page container is positioned correctly for absolute centering */
+:host {
+    position: relative;
+    display: block;
+    min-height: 30vh;
+}


### PR DESCRIPTION
## Summary
- style the Home page text overlay with `-webkit-text-stroke` so the video shows through

## Testing
- `dotnet build BlazorHybridApp.sln` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f79b300a88322acdd8cc2e86d9552