### PR TITLE
Register BackgroundVideo as custom element

### DIFF
--- a/BlazorHybridApp.Client/Pages/Home.razor
+++ b/BlazorHybridApp.Client/Pages/Home.razor
@@ -5,4 +5,10 @@
 
 <h1 id="homeTitle">Thank you coop</h1>
 
-<BackgroundVideo/>
+<div>
+    @((MarkupString)htmlWithWebComponent)
+</div>
+
+@code {
+    private const string htmlWithWebComponent = "<background-video></background-video>";
+}

--- a/BlazorHybridApp.Client/Program.cs
+++ b/BlazorHybridApp.Client/Program.cs
@@ -1,6 +1,9 @@
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using BlazorHybridApp.Client.Pages;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
+
+builder.RootComponents.RegisterCustomElement<BackgroundVideo>("background-video");
 
 builder.Services.AddAuthorizationCore();
 builder.Services.AddCascadingAuthenticationState();

--- a/BlazorHybridApp/Program.cs
+++ b/BlazorHybridApp/Program.cs
@@ -10,6 +10,8 @@ using BlazorHybridApp.Data;
 
 var builder = WebApplication.CreateBuilder(args);
 
+builder.RootComponents.RegisterCustomElement<BackgroundVideo>("background-video");
+
 // Add services to the container.
 builder.Services.AddRazorComponents()
     .AddInteractiveServerComponents()


### PR DESCRIPTION
## Summary
- register BackgroundVideo as a custom element on both the client and server
- use markup string with the custom element in `Home.razor`

## Testing
- `npm test` *(fails: Missing script)*
- `dotnet build BlazorHybridApp.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd339a3c083228d8d7d3ac6fed6e1