### PR TITLE
Add counter2 page with custom element

### DIFF
--- a/BlazorHybridApp.Client/BlazorHybridApp.Client.csproj
+++ b/BlazorHybridApp.Client/BlazorHybridApp.Client.csproj
@@ -11,6 +11,7 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="9.0.5" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="9.0.5" />
+    <PackageReference Include="Microsoft.AspNetCore.Components.CustomElements" Version="9.0.5" />
   </ItemGroup>
 
 </Project>

--- a/BlazorHybridApp.Client/Pages/Counter2.razor
+++ b/BlazorHybridApp.Client/Pages/Counter2.razor
@@ -1,0 +1,14 @@
+@page "/counter2"
+@rendermode InteractiveWebAssembly
+@using Microsoft.AspNetCore.Components
+
+<PageTitle>Counter 2</PageTitle>
+
+<h1>Counter 2</h1>
+
+@{
+    var counterHtml = (MarkupString)"<my-counter></my-counter>";
+}
+
+<div>@counterHtml</div>
+

--- a/BlazorHybridApp.Client/Program.cs
+++ b/BlazorHybridApp.Client/Program.cs
@@ -1,10 +1,15 @@
+using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
+using BlazorHybridApp.Client.Pages;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
 builder.Services.AddAuthorizationCore();
 builder.Services.AddCascadingAuthenticationState();
 builder.Services.AddAuthenticationStateDeserialization();
+
+// Register Counter component as custom element <my-counter>
+builder.RootComponents.RegisterCustomElement<Counter>("my-counter");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
 

--- a/BlazorHybridApp.Client/wwwroot/index.html
+++ b/BlazorHybridApp.Client/wwwroot/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Blazor Custom Element Demo</title>
+    <base href="/" />
+</head>
+<body>
+    <my-counter></my-counter>
+
+    <script src="_content/Microsoft.AspNetCore.Components.CustomElements/BlazorCustomElements.js"></script>
+    <script src="_framework/blazor.webassembly.js"></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- register custom element `<my-counter>` that wraps existing Counter component
- expose Counter2 page rendering `<my-counter>` via `MarkupString`
- include Blazor Custom Elements package
- add a standalone `index.html` demonstrating use of the custom element

## Testing
- `dotnet build BlazorHybridApp.Client/BlazorHybridApp.Client.csproj -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fe25dbbb8832297236b5696fcf179