### PR TITLE
Fix D3 demo on WASM

### DIFF
--- a/BlazorHybridApp/Components/App.razor
+++ b/BlazorHybridApp/Components/App.razor
@@ -15,6 +15,10 @@
 
 <body>
     <Routes />
+    <script src="@Assets["lib/d3/dist/d3.min.js"]"></script>
+    <script src="@Assets["lib/d3-hexbin/build/d3-hexbin.min.js"]"></script>
+    <script src="@Assets["js/d3demo.js"]"></script>
+    <script src="@Assets["_content/Microsoft.AspNetCore.Components.CustomElements/BlazorCustomElements.js"]"></script>
     <script src="_framework/blazor.web.js"></script>
 </body>
 


### PR DESCRIPTION
## Summary
- load D3 libraries in the server's root component so the WASM page can invoke `d3Demo.init`

## Testing
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683ff533b67483228b700c50718ef341