### PR TITLE
Add language preference switcher

### DIFF
--- a/BlazorHybridApp.Client/wwwroot/js/localization.js
+++ b/BlazorHybridApp.Client/wwwroot/js/localization.js
@@ -1,0 +1,11 @@
+window.localization = {
+  getBrowserLanguages: function () {
+    if (navigator.languages && navigator.languages.length) {
+      return navigator.languages;
+    }
+    if (navigator.language) {
+      return [navigator.language];
+    }
+    return [];
+  }
+};

--- a/BlazorHybridApp/Components/App.razor
+++ b/BlazorHybridApp/Components/App.razor
@@ -18,6 +18,7 @@
     <script src="@Assets["lib/d3/dist/d3.min.js"]"></script>
     <script src="@Assets["lib/d3-hexbin/build/d3-hexbin.min.js"]"></script>
     <script src="@Assets["js/d3demo.js"]"></script>
+    <script src="@Assets["js/localization.js"]"></script>
     <script src="@Assets["_content/Microsoft.AspNetCore.Components.CustomElements/BlazorCustomElements.js"]"></script>
     <script src="_framework/blazor.web.js"></script>
 </body>

--- a/BlazorHybridApp/Components/LanguageSwitcher.razor
+++ b/BlazorHybridApp/Components/LanguageSwitcher.razor
@@ -1,0 +1,49 @@
+@using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage
+@inject ProtectedLocalStorage Storage
+@inject IJSRuntime JS
+@inject AuthenticationStateProvider AuthProvider
+
+<div class="language-switcher">
+    <button class="btn btn-link" @onclick="() => SetLanguage(\"EN\")">EN</button>
+    <button class="btn btn-link" @onclick="() => SetLanguage(\"JP\")">JP</button>
+    <span class="ms-2">@currentLanguage</span>
+</div>
+
+@code {
+    private const string StorageKey = "preferredLanguage";
+    private string currentLanguage = "EN";
+
+    protected override async Task OnInitializedAsync()
+    {
+        var stored = await Storage.GetAsync<string>(StorageKey);
+        if (stored.Success && !string.IsNullOrWhiteSpace(stored.Value))
+        {
+            currentLanguage = stored.Value;
+        }
+        else
+        {
+            var authState = await AuthProvider.GetAuthenticationStateAsync();
+            if (!authState.User.Identity?.IsAuthenticated ?? true)
+            {
+                try
+                {
+                    var langs = await JS.InvokeAsync<string[]>("localization.getBrowserLanguages");
+                    if (langs != null && langs.Any(l => l.StartsWith("ja", StringComparison.OrdinalIgnoreCase)))
+                    {
+                        currentLanguage = "JP";
+                    }
+                }
+                catch
+                {
+                    // ignore errors and keep default
+                }
+            }
+        }
+    }
+
+    private async Task SetLanguage(string lang)
+    {
+        currentLanguage = lang;
+        await Storage.SetAsync(StorageKey, currentLanguage);
+    }
+}

--- a/BlazorHybridApp/Components/Layout/MainLayout.razor
+++ b/BlazorHybridApp/Components/Layout/MainLayout.razor
@@ -15,7 +15,7 @@
 
     <main>
         <div class="top-row px-4">
-            <a href="https://learn.microsoft.com/aspnet/core/" target="_blank">About</a>
+            <LanguageSwitcher />
         </div>
 
         <article class="content px-4">

--- a/BlazorHybridApp/Program.cs
+++ b/BlazorHybridApp/Program.cs
@@ -6,6 +6,7 @@ using BlazorHybridApp.Components.Account;
 using BlazorHybridApp.Services;
 using BlazorHybridApp.Data;
 using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Components.Server.ProtectedBrowserStorage;
 
 const int WaterfallVideoId = 6394054;
 const int GoatVideoId = 30646036;
@@ -50,6 +51,7 @@ builder.Services.AddIdentityCore<ApplicationUser>(options => options.SignIn.Requ
 builder.Services.AddSingleton<IEmailSender, EmailSender>();
 builder.Services.AddSingleton<IEmailSender<ApplicationUser>, IdentityEmailSender>();
 builder.Services.AddHttpClient<PexelsClient>();
+builder.Services.AddScoped<ProtectedLocalStorage>();
 
 var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- add a LanguageSwitcher component
- store user selection in protected browser storage
- guess initial language based on browser when not authenticated
- register ProtectedLocalStorage and load script
- show switcher in MainLayout

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684678d83ed08322844af386992b2ca0