### PR TITLE
Fix quotes in LanguageSwitcher Razor component

### DIFF
--- a/BlazorHybridApp/Components/LanguageSwitcher.razor
+++ b/BlazorHybridApp/Components/LanguageSwitcher.razor
@@ -4,8 +4,8 @@
 @inject AuthenticationStateProvider AuthProvider
 
 <div class="language-switcher">
-    <button class="btn btn-link" @onclick="() => SetLanguage(\"EN\")">EN</button>
-    <button class="btn btn-link" @onclick="() => SetLanguage(\"JP\")">JP</button>
+    <button class="btn btn-link" @onclick='() => SetLanguage("EN")'>EN</button>
+    <button class="btn btn-link" @onclick='() => SetLanguage("JP")'>JP</button>
     <span class="ms-2">@currentLanguage</span>
 </div>
 


### PR DESCRIPTION
## Summary
- fix onclick button quoting in `LanguageSwitcher.razor`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467a88b8d48322b8845cf8a0c57fd6