### PR TITLE
Add LangSwitchButton and LocalizationService for WASM

### DIFF
--- a/BlazorHybridApp.Client/Components/Layout/LangSwitchButton.razor
+++ b/BlazorHybridApp.Client/Components/Layout/LangSwitchButton.razor
@@ -1,0 +1,76 @@
+@using BlazorHybridApp.Client.Services
+@implements IDisposable
+@inject LocalizationService Localization
+@inject NavigationManager NavigationManager
+@rendermode InteractiveWebAssembly
+
+<div class="dropdown lang-switch">
+    <button class="btn btn-secondary dropdown-toggle" @onclick="ToggleDropdown">
+        🌐 @GetCurrentCultureLabel()
+    </button>
+    <ul class="dropdown-menu @(GetDropdownMenuClass())">
+        <li>
+            <button class="dropdown-item @(GetActiveClass("en"))" @onclick="() => SetLanguage("en")">
+                English @GetCheckmark("en")
+            </button>
+        </li>
+        <li>
+            <button class="dropdown-item @(GetActiveClass("ja"))" @onclick="() => SetLanguage("ja")">
+                日本語 @GetCheckmark("ja")
+            </button>
+        </li>
+    </ul>
+</div>
+
+@code {
+    private bool isDropdownOpen;
+    private bool initialized = false;
+
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && !initialized)
+        {
+            await Localization.LoadCultureAsync();
+            Localization.OnChange += StateHasChanged;
+            initialized = true;
+            StateHasChanged();
+        }
+    }
+
+    private void ToggleDropdown()
+    {
+        isDropdownOpen = !isDropdownOpen;
+    }
+
+    private async Task SetLanguage(string culture)
+    {
+        isDropdownOpen = false;
+        await Localization.SetCultureAsync(culture);
+        NavigationManager.NavigateTo(NavigationManager.Uri, forceLoad: true);
+    }
+
+    private string GetCurrentCultureLabel()
+    {
+        return Localization.CurrentCulture.Name.StartsWith("ja") ? "JA" : "EN";
+    }
+
+    private string GetDropdownMenuClass()
+    {
+        return isDropdownOpen ? "show" : string.Empty;
+    }
+
+    private string GetActiveClass(string culture)
+    {
+        return Localization.CurrentCulture.Name.StartsWith(culture) ? "active" : string.Empty;
+    }
+
+    private string GetCheckmark(string culture)
+    {
+        return Localization.CurrentCulture.Name.StartsWith(culture) ? "✔️" : string.Empty;
+    }
+
+    public void Dispose()
+    {
+        Localization.OnChange -= StateHasChanged;
+    }
+}

--- a/BlazorHybridApp.Client/Components/Layout/LangSwitchButton.razor.css
+++ b/BlazorHybridApp.Client/Components/Layout/LangSwitchButton.razor.css
@@ -1,0 +1,10 @@
+@media (min-width: 641px) {
+    .lang-switch {
+        position: relative;
+    }
+
+    .lang-switch .dropdown-menu {
+        right: 0;
+        left: auto;
+    }
+}

--- a/BlazorHybridApp.Client/Program.cs
+++ b/BlazorHybridApp.Client/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Components.Web;
 using Microsoft.AspNetCore.Components.WebAssembly.Hosting;
 using BlazorHybridApp.Client.Pages;
+using BlazorHybridApp.Client.Services;
 
 var builder = WebAssemblyHostBuilder.CreateDefault(args);
 
@@ -12,5 +13,6 @@ builder.Services.AddAuthenticationStateDeserialization();
 builder.RootComponents.RegisterCustomElement<Counter>("my-counter");
 
 builder.Services.AddScoped(sp => new HttpClient { BaseAddress = new Uri(builder.HostEnvironment.BaseAddress) });
+builder.Services.AddScoped<LocalizationService>();
 
 await builder.Build().RunAsync();

--- a/BlazorHybridApp.Client/Services/LocalizationService.cs
+++ b/BlazorHybridApp.Client/Services/LocalizationService.cs
@@ -1,0 +1,60 @@
+using System.Globalization;
+using Microsoft.JSInterop;
+
+namespace BlazorHybridApp.Client.Services;
+
+public class LocalizationService
+{
+    private readonly IJSRuntime _js;
+    private bool _loaded;
+    public event Action? OnChange;
+
+    public LocalizationService(IJSRuntime js)
+    {
+        _js = js;
+        CurrentCulture = CultureInfo.CurrentCulture;
+    }
+
+    public CultureInfo CurrentCulture { get; private set; }
+
+    public async Task LoadCultureAsync()
+    {
+        if (_loaded)
+        {
+            return;
+        }
+
+        var culture = await _js.InvokeAsync<string>("localization.getPreferredLanguage");
+        if (string.IsNullOrEmpty(culture))
+        {
+            var langs = await _js.InvokeAsync<string[]>("localization.getBrowserLanguages");
+            if (langs != null && langs.Any(l => l.StartsWith("ja", StringComparison.OrdinalIgnoreCase)))
+            {
+                culture = "ja";
+            }
+            else
+            {
+                culture = "en";
+            }
+        }
+
+        SetThreadCulture(culture);
+        _loaded = true;
+        OnChange?.Invoke();
+    }
+
+    public async Task SetCultureAsync(string culture)
+    {
+        await _js.InvokeVoidAsync("localization.setPreferredLanguage", culture);
+        SetThreadCulture(culture);
+        OnChange?.Invoke();
+    }
+
+    private void SetThreadCulture(string culture)
+    {
+        var cultureInfo = new CultureInfo(culture);
+        CultureInfo.DefaultThreadCurrentCulture = cultureInfo;
+        CultureInfo.DefaultThreadCurrentUICulture = cultureInfo;
+        CurrentCulture = cultureInfo;
+    }
+}

--- a/BlazorHybridApp.Client/_Imports.razor
+++ b/BlazorHybridApp.Client/_Imports.razor
@@ -9,3 +9,4 @@
 @using Microsoft.JSInterop
 @using BlazorHybridApp.Client
 @using BlazorHybridApp.Client.Components.Layout
+@using BlazorHybridApp.Client.Services

--- a/BlazorHybridApp.Client/wwwroot/js/localization.js
+++ b/BlazorHybridApp.Client/wwwroot/js/localization.js
@@ -7,5 +7,11 @@ window.localization = {
       return [navigator.language];
     }
     return [];
+  },
+  getPreferredLanguage: function () {
+    return localStorage.getItem('blazorCulture');
+  },
+  setPreferredLanguage: function (culture) {
+    localStorage.setItem('blazorCulture', culture);
   }
 };

--- a/BlazorHybridApp/Components/Layout/MainLayout.razor
+++ b/BlazorHybridApp/Components/Layout/MainLayout.razor
@@ -15,7 +15,7 @@
 
     <main>
         <div class="top-row px-4">
-            <LanguageSwitcher />
+            <LangSwitchButton />
         </div>
 
         <article class="content px-4">


### PR DESCRIPTION
## Summary
- add JS helpers for storing preferred language
- create LocalizationService for Blazor WASM
- add LangSwitchButton component with dropdown UI
- register the service and update imports
- hook LangSwitchButton into MainLayout

## Testing
- `npm -v`
- `dotnet build` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68467f0afec8832288ce44ae671169b2