### PR TITLE
Implement fallback poster image

### DIFF
--- a/BlazorHybridApp.Client/Pages/BackgroundVideo.razor
+++ b/BlazorHybridApp.Client/Pages/BackgroundVideo.razor
@@ -7,5 +7,5 @@
 <script src="js/background-video.js"></script>
 
 }else{
-    @* show still image from pexel of video-1 in EXACTLY the same dimension.  The image should be kept as cached file as part of the data seeding *@
+    <img id="background-image" class="background-video" src="media/waterfall-poster.jpg" alt="Waterfall background" />
 }


### PR DESCRIPTION
## Summary
- cache the waterfall poster image during seeding
- return the cached poster path
- use the cached poster when not running interactively

## Testing
- `npm test` *(fails: Missing script)*
- `dotnet build BlazorHybridApp.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684690319e1883228334bce008106a3f