### PR TITLE
Add basic CMS content interfaces and HTML seeding

### DIFF
--- a/BlazorHybridApp/Data/ApplicationDbContext.cs
+++ b/BlazorHybridApp/Data/ApplicationDbContext.cs
@@ -6,4 +6,5 @@ namespace BlazorHybridApp.Data;
 public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options) : IdentityDbContext<ApplicationUser>(options)
 {
     public DbSet<BackgroundVideo> BackgroundVideos => Set<BackgroundVideo>();
+    public DbSet<HtmlContent> HtmlContents => Set<HtmlContent>();
 }

--- a/BlazorHybridApp/Data/DataSeeder.cs
+++ b/BlazorHybridApp/Data/DataSeeder.cs
@@ -37,6 +37,22 @@ public static class DataSeeder
         await db.SaveChangesAsync(cancellationToken);
     }
 
+    public static async Task SeedHtmlContentsAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+    {
+        using var scope = services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        if (await db.HtmlContents.AnyAsync(cancellationToken))
+            return;
+
+        db.HtmlContents.Add(new HtmlContent
+        {
+            Html = "<p>Hello, world!</p>"
+        });
+
+        await db.SaveChangesAsync(cancellationToken);
+    }
+
     public static async Task SeedDefaultUsersAsync(IServiceProvider services, string password, CancellationToken cancellationToken = default)
     {
         using var scope = services.CreateScope();

--- a/BlazorHybridApp/Data/HtmlContent.cs
+++ b/BlazorHybridApp/Data/HtmlContent.cs
@@ -1,0 +1,7 @@
+namespace BlazorHybridApp.Data;
+
+public class HtmlContent : IContent, IHtmlContent
+{
+    public Guid Id { get; init; } = Guid.NewGuid();
+    public string Html { get; set; } = string.Empty;
+}

--- a/BlazorHybridApp/Data/IContent.cs
+++ b/BlazorHybridApp/Data/IContent.cs
@@ -1,0 +1,6 @@
+namespace BlazorHybridApp.Data;
+
+public interface IContent
+{
+    Guid Id { get; }
+}

--- a/BlazorHybridApp/Data/IHtmlContent.cs
+++ b/BlazorHybridApp/Data/IHtmlContent.cs
@@ -1,0 +1,6 @@
+namespace BlazorHybridApp.Data;
+
+public interface IHtmlContent
+{
+    string Html { get; set; }
+}

--- a/BlazorHybridApp/Program.cs
+++ b/BlazorHybridApp/Program.cs
@@ -62,6 +62,7 @@ using (var scope = app.Services.CreateScope())
         var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
         db.Database.EnsureCreated();
         DataSeeder.SeedBackgroundVideosAsync(scope.ServiceProvider).GetAwaiter().GetResult();
+        DataSeeder.SeedHtmlContentsAsync(scope.ServiceProvider).GetAwaiter().GetResult();
         DataSeeder.SeedDefaultUsersAsync(scope.ServiceProvider, defaultUserPassword).GetAwaiter().GetResult();
 }
 


### PR DESCRIPTION
## Summary
- introduce `IContent` and `IHtmlContent` interfaces
- implement `HtmlContent` class with automatic UUID
- register `HtmlContent` in `ApplicationDbContext`
- seed sample HTML content and call the seeder

## Testing
- `npm test` *(fails: Missing script)*
- `npm ci` *(failed: network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68469d96c8b08322905d8be74f310e75