### PR TITLE
Add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Codex Instructions
+
+- Do **not** run `npm ci` or `npm install` during testing or setup.
+- Node/NPM is only present for optional Playwright tests and is not required for building or running the application.


### PR DESCRIPTION
## Summary
- add AGENTS instructions to skip npm install/ci since only Playwright uses Node

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68469ebbff048322a0fa083bc9cd8fa4