### PR TITLE
Add EF model inspection page

### DIFF
--- a/BlazorHybridApp.Client/Components/Layout/ClientNavMenu.razor
+++ b/BlazorHybridApp.Client/Components/Layout/ClientNavMenu.razor
@@ -43,5 +43,11 @@
                 <span class="bi bi-lock-nav-menu" aria-hidden="true"></span> Auth Required
             </NavLink>
         </div>
+
+        <div class="nav-item px-3">
+            <NavLink class="nav-link" href="inspect">
+                <span class="bi bi-person-badge-nav-menu" aria-hidden="true"></span> Self Inspection
+            </NavLink>
+        </div>
     </nav>
 </div>

--- a/BlazorHybridApp.Client/Pages/SelfInspection.razor
+++ b/BlazorHybridApp.Client/Pages/SelfInspection.razor
@@ -1,0 +1,38 @@
+@page "/inspect"
+@rendermode InteractiveWebAssembly
+
+<PageTitle>Self Inspection</PageTitle>
+
+<h1>Entity Framework Model</h1>
+
+@if (entities is null)
+{
+    <p>Loading...</p>
+}
+else
+{
+    @foreach (var entity in entities)
+    {
+        <h3>@entity.Name</h3>
+        <ul>
+            @foreach (var prop in entity.Properties)
+            {
+                <li>@prop.Name (@prop.Type)</li>
+            }
+        </ul>
+    }
+}
+
+@code {
+    [Inject] HttpClient Http { get; set; } = default!;
+
+    private List<EntityInfo>? entities;
+
+    protected override async Task OnInitializedAsync()
+    {
+        entities = await Http.GetFromJsonAsync<List<EntityInfo>>("/api/ef-model");
+    }
+
+    private record EntityInfo(string Name, List<PropertyInfo> Properties);
+    private record PropertyInfo(string Name, string Type);
+}

--- a/BlazorHybridApp/Program.cs
+++ b/BlazorHybridApp/Program.cs
@@ -152,6 +152,16 @@ app.MapGet("/api/goat-video-url", async (ApplicationDbContext db, PexelsClient c
     return Results.Json(new { url });
 });
 
+app.MapGet("/api/ef-model", (ApplicationDbContext db) =>
+{
+    var entities = db.Model.GetEntityTypes().Select(e => new
+    {
+        Name = e.ClrType.Name,
+        Properties = e.GetProperties().Select(p => new { Name = p.Name, Type = p.ClrType.Name })
+    });
+    return Results.Json(entities);
+});
+
 app.MapPost("/api/upload-test", async (HttpContext context) =>
 {
     long count = 0;


### PR DESCRIPTION
## Summary
- add new self-inspection page that displays EF entities
- add API endpoint to fetch EF model info
- link to new inspection page from client nav menu

## Testing
- `dotnet test --no-build` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a0d7c8d0832297debb9d7fbca423