### PR TITLE
Fix SelfInspection page HttpClient usage

### DIFF
--- a/BlazorHybridApp.Client/Pages/SelfInspection.razor
+++ b/BlazorHybridApp.Client/Pages/SelfInspection.razor
@@ -25,12 +25,17 @@ else
 
 @code {
     [Inject] HttpClient Http { get; set; } = default!;
+    [Inject] NavigationManager Nav { get; set; } = default!;
 
     private List<EntityInfo>? entities;
 
     protected override async Task OnInitializedAsync()
     {
-        entities = await Http.GetFromJsonAsync<List<EntityInfo>>("/api/ef-model");
+        if (Http.BaseAddress is null)
+        {
+            Http = new HttpClient { BaseAddress = new Uri(Nav.BaseUri) };
+        }
+        entities = await Http.GetFromJsonAsync<List<EntityInfo>>("api/ef-model");
     }
 
     private record EntityInfo(string Name, List<PropertyInfo> Properties);


### PR DESCRIPTION
## Summary
- ensure `HttpClient` has a base address when loading the self-inspection page

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846a70ab6488322b10c370f79831ea6