### PR TITLE
Add EF inspection D3 visualization

### DIFF
--- a/BlazorHybridApp.Client/Pages/SelfInspection.razor
+++ b/BlazorHybridApp.Client/Pages/SelfInspection.razor
@@ -11,6 +11,7 @@
 }
 else
 {
+    <div id="ef-diagram" style="height:400px" class="mb-4"></div>
     @foreach (var entity in entities)
     {
         <h3>@entity.Name</h3>
@@ -26,6 +27,7 @@ else
 @code {
     [Inject] HttpClient Http { get; set; } = default!;
     [Inject] NavigationManager Nav { get; set; } = default!;
+    [Inject] IJSRuntime JS { get; set; } = default!;
 
     private List<EntityInfo>? entities;
 
@@ -38,6 +40,14 @@ else
         entities = await Http.GetFromJsonAsync<List<EntityInfo>>("api/ef-model");
     }
 
-    private record EntityInfo(string Name, List<PropertyInfo> Properties);
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        if (firstRender && entities is not null)
+        {
+            await JS.InvokeVoidAsync("efInspection.render", entities);
+        }
+    }
+    private record EntityInfo(string Name, List<PropertyInfo> Properties, List<NavigationInfo> Navigations);
     private record PropertyInfo(string Name, string Type);
+    private record NavigationInfo(string Name, string Target);
 }

--- a/BlazorHybridApp.Client/wwwroot/index.html
+++ b/BlazorHybridApp.Client/wwwroot/index.html
@@ -12,6 +12,7 @@
     <script src="lib/d3/dist/d3.min.js"></script>
     <script src="lib/d3-hexbin/build/d3-hexbin.min.js"></script>
     <script src="js/d3demo.js"></script>
+    <script src="js/efinspection.js"></script>
     <script src="_content/Microsoft.AspNetCore.Components.CustomElements/BlazorCustomElements.js"></script>
     <script src="_framework/blazor.webassembly.js"></script>
 </body>

--- a/BlazorHybridApp.Client/wwwroot/js/efinspection.js
+++ b/BlazorHybridApp.Client/wwwroot/js/efinspection.js
@@ -1,0 +1,91 @@
+window.efInspection = {
+  render: function(entities) {
+    var nodes = entities.map(e => ({ id: e.name }));
+    var links = [];
+    entities.forEach(e => {
+      if (e.navigations) {
+        e.navigations.forEach(n => {
+          links.push({ source: e.name, target: n.target });
+        });
+      }
+    });
+
+    var container = document.getElementById('ef-diagram');
+    if (!container) return;
+    var width = container.clientWidth || 600;
+    var height = container.clientHeight || 400;
+    d3.select(container).selectAll('svg').remove();
+    var svg = d3.select(container)
+      .append('svg')
+      .attr('width', width)
+      .attr('height', height);
+
+    var link = svg.append('g')
+      .attr('stroke', '#999')
+      .attr('stroke-opacity', 0.6)
+      .selectAll('line')
+      .data(links)
+      .enter().append('line')
+      .attr('stroke-width', 1.5);
+
+    var node = svg.append('g')
+      .attr('stroke', '#fff')
+      .attr('stroke-width', 1.5)
+      .selectAll('circle')
+      .data(nodes)
+      .enter().append('circle')
+      .attr('r', 20)
+      .attr('fill', 'steelblue')
+      .call(d3.drag()
+        .on('start', dragstarted)
+        .on('drag', dragged)
+        .on('end', dragended));
+
+    var label = svg.append('g')
+      .selectAll('text')
+      .data(nodes)
+      .enter().append('text')
+      .text(d => d.id)
+      .attr('font-size', '10px')
+      .attr('text-anchor', 'middle')
+      .attr('dy', '.35em');
+
+    var simulation = d3.forceSimulation(nodes)
+      .force('link', d3.forceLink(links).id(d => d.id).distance(100))
+      .force('charge', d3.forceManyBody().strength(-200))
+      .force('center', d3.forceCenter(width / 2, height / 2));
+
+    simulation.on('tick', () => {
+      link
+        .attr('x1', d => d.source.x)
+        .attr('y1', d => d.source.y)
+        .attr('x2', d => d.target.x)
+        .attr('y2', d => d.target.y);
+
+      node
+        .attr('cx', d => d.x)
+        .attr('cy', d => d.y);
+
+      label
+        .attr('x', d => d.x)
+        .attr('y', d => d.y);
+    });
+
+    function dragstarted(event, d) {
+      if (!event.active) simulation.alphaTarget(0.3).restart();
+      d.fx = d.x;
+      d.fy = d.y;
+    }
+
+    function dragged(event, d) {
+      d.fx = event.x;
+      d.fy = event.y;
+    }
+
+    function dragended(event, d) {
+      if (!event.active) simulation.alphaTarget(0);
+      d.fx = null;
+      d.fy = null;
+    }
+  }
+};

--- a/BlazorHybridApp/Program.cs
+++ b/BlazorHybridApp/Program.cs
@@ -158,7 +158,8 @@ app.MapGet("/api/ef-model", (ApplicationDbContext db) =>
     var entities = db.Model.GetEntityTypes().Select(e => new
     {
         Name = e.ClrType.Name,
-        Properties = e.GetProperties().Select(p => new { Name = p.Name, Type = p.ClrType.Name })
+        Properties = e.GetProperties().Select(p => new { Name = p.Name, Type = p.ClrType.Name }),
+        Navigations = e.GetNavigations().Select(n => new { Name = n.Name, Target = n.TargetEntityType.ClrType.Name })
     });
     return Results.Json(entities);
 });


### PR DESCRIPTION
## Summary
- extend `/api/ef-model` endpoint to include navigation data
- add D3 visualization script to draw force-directed graphs
- render graph on Self Inspection page
- load the new script in the webassembly host

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846aa3328888322893bcc4a25cd2a18