### PR TITLE
Improve EF inspector diagrams

### DIFF
--- a/BlazorHybridApp.Client/Pages/SelfInspection.razor
+++ b/BlazorHybridApp.Client/Pages/SelfInspection.razor
@@ -21,6 +21,16 @@ else
                 <li>@prop.Name (@prop.Type)</li>
             }
         </ul>
+        @if (entity.Navigations?.Count > 0)
+        {
+            <h4>Relations</h4>
+            <ul>
+                @foreach (var nav in entity.Navigations)
+                {
+                    <li>@nav.Name &rarr; @nav.Target</li>
+                }
+            </ul>
+        }
     }
 }
 

--- a/BlazorHybridApp.Client/wwwroot/js/efinspection.js
+++ b/BlazorHybridApp.Client/wwwroot/js/efinspection.js
@@ -20,13 +20,29 @@ window.efInspection = {
       .attr('width', width)
       .attr('height', height);
 
+    // draw arrowheads for links
+    var defs = svg.append('defs');
+    defs.append('marker')
+      .attr('id', 'arrow')
+      .attr('viewBox', '0 0 10 10')
+      .attr('refX', 25)
+      .attr('refY', 5)
+      .attr('markerWidth', 6)
+      .attr('markerHeight', 6)
+      .attr('orient', 'auto')
+      .append('path')
+        .attr('d', 'M0,0 L10,5 L0,10 Z')
+        .attr('fill', '#666');
+
     var link = svg.append('g')
       .attr('stroke', '#999')
       .attr('stroke-opacity', 0.6)
-      .selectAll('line')
+      .selectAll('path')
       .data(links)
-      .enter().append('line')
-      .attr('stroke-width', 1.5);
+      .enter().append('path')
+      .attr('stroke-width', 1.5)
+      .attr('fill', 'none')
+      .attr('marker-end', 'url(#arrow)');
 
     var node = svg.append('g')
       .attr('stroke', '#fff')
@@ -57,10 +73,9 @@ window.efInspection = {
 
     simulation.on('tick', () => {
       link
-        .attr('x1', d => d.source.x)
-        .attr('y1', d => d.source.y)
-        .attr('x2', d => d.target.x)
-        .attr('y2', d => d.target.y);
+        .attr('d', d =>
+          `M${d.source.x},${d.source.y} L${d.target.x},${d.target.y}`
+        );
 
       node
         .attr('cx', d => d.x)


### PR DESCRIPTION
## Summary
- show navigation relations in `SelfInspection` page
- add arrowheads to EF inspector graph links for clearer direction

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846bc6ee6c88322962a4f6714830edb