### PR TITLE
Fix EF inspector height for large diagrams

### DIFF
--- a/BlazorHybridApp.Client/Pages/SelfInspection.razor
+++ b/BlazorHybridApp.Client/Pages/SelfInspection.razor
@@ -11,7 +11,7 @@
 }
 else
 {
-    <div id="ef-diagram" style="height:400px" class="mb-4"></div>
+    <div id="ef-diagram" class="mb-4"></div>
     @foreach (var entity in entities)
     {
         <h3>@entity.Name</h3>

--- a/BlazorHybridApp.Client/Pages/SelfInspection.razor.css
+++ b/BlazorHybridApp.Client/Pages/SelfInspection.razor.css
@@ -1,0 +1,4 @@
+#ef-diagram {
+    height: 70vh;
+    overflow: auto;
+}


### PR DESCRIPTION
## Summary
- make EF inspector diagram scrollable with CSS
- remove hard-coded height from the Self Inspection page

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846bf0d534083229d8764ddcb9ed3c2