### PR TITLE
Add EF inspector row data

### DIFF
--- a/BlazorHybridApp.Client/Pages/SelfInspection.razor
+++ b/BlazorHybridApp.Client/Pages/SelfInspection.razor
@@ -53,6 +53,31 @@ else
                 </tbody>
             </table>
         }
+        @if (entity.Rows?.Count > 0)
+        {
+            <h4>Top Rows</h4>
+            <table class="table table-bordered table-sm mb-4">
+                <thead class="table-light">
+                    <tr>
+                        @foreach (var prop in entity.Properties)
+                        {
+                            <th>@prop.Name</th>
+                        }
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var row in entity.Rows)
+                    {
+                        <tr>
+                            @foreach (var prop in entity.Properties)
+                            {
+                                <td>@row[prop.Name]</td>
+                            }
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        }
     }
 }
 
@@ -79,7 +104,11 @@ else
             await JS.InvokeVoidAsync("efInspection.render", entities);
         }
     }
-    private record EntityInfo(string Name, List<PropertyInfo> Properties, List<NavigationInfo> Navigations);
+    private record EntityInfo(
+        string Name,
+        List<PropertyInfo> Properties,
+        List<NavigationInfo> Navigations,
+        List<Dictionary<string, string?>> Rows);
     private record PropertyInfo(string Name, string Type);
     private record NavigationInfo(string Name, string Target);
 }


### PR DESCRIPTION
## Summary
- extend `/api/ef-model` endpoint to also return sample rows from each entity
- display these rows in the Self Inspection page
- add missing `System.Collections.Generic` using

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846c137b8108322a5317a6b50661756