### PR TITLE
Fix dynamic entity query compilation error

### DIFF
--- a/BlazorHybridApp/Data/DbContextExtensions.cs
+++ b/BlazorHybridApp/Data/DbContextExtensions.cs
@@ -1,0 +1,17 @@
+using Microsoft.EntityFrameworkCore;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace BlazorHybridApp.Data;
+
+public static class DbContextExtensions
+{
+    public static IQueryable<object> GetQueryable(this DbContext context, Type entityType)
+    {
+        var method = typeof(DbContext).GetMethods()
+            .First(m => m.Name == nameof(DbContext.Set) && m.IsGenericMethod && m.GetParameters().Length == 0);
+        var generic = method.MakeGenericMethod(entityType);
+        return (IQueryable<object>)(generic.Invoke(context, null) ?? throw new InvalidOperationException($"Could not create set for {entityType.Name}"));
+    }
+}

--- a/BlazorHybridApp/Program.cs
+++ b/BlazorHybridApp/Program.cs
@@ -170,7 +170,7 @@ app.MapGet("/api/ef-model", async (ApplicationDbContext db) =>
         var rows = new List<Dictionary<string, string?>>();
         try
         {
-            var rowObjects = await db.Set(e.ClrType).Cast<object>().Take(5).ToListAsync();
+            var rowObjects = await db.GetQueryable(e.ClrType).Take(5).ToListAsync();
             foreach (var obj in rowObjects)
             {
                 var dict = new Dictionary<string, string?>();


### PR DESCRIPTION
## Summary
- use reflection-based helper `GetQueryable` to resolve DbContext Set
- update Program to use new helper

## Testing
- ❌ `dotnet run` *(fails: `dotnet: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6846c3f3bedc8322a8c71038727de0ce