### PR TITLE
Add BranchOfficeContent type

### DIFF
--- a/BlazorHybridApp/Data/ApplicationDbContext.cs
+++ b/BlazorHybridApp/Data/ApplicationDbContext.cs
@@ -7,4 +7,5 @@ public class ApplicationDbContext(DbContextOptions<ApplicationDbContext> options
 {
     public DbSet<BackgroundVideo> BackgroundVideos => Set<BackgroundVideo>();
     public DbSet<HtmlContent> HtmlContents => Set<HtmlContent>();
+    public DbSet<BranchOfficeContent> BranchOfficeContents => Set<BranchOfficeContent>();
 }

--- a/BlazorHybridApp/Data/BranchOfficeContent.cs
+++ b/BlazorHybridApp/Data/BranchOfficeContent.cs
@@ -1,0 +1,7 @@
+namespace BlazorHybridApp.Data;
+
+public class BranchOfficeContent : IContent
+{
+    public Guid Id { get; init; } = Guid.NewGuid();
+    public string Address { get; set; } = string.Empty;
+}

--- a/BlazorHybridApp/Data/DataSeeder.cs
+++ b/BlazorHybridApp/Data/DataSeeder.cs
@@ -53,6 +53,22 @@ public static class DataSeeder
         await db.SaveChangesAsync(cancellationToken);
     }
 
+    public static async Task SeedBranchOfficeContentsAsync(IServiceProvider services, CancellationToken cancellationToken = default)
+    {
+        using var scope = services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        if (await db.BranchOfficeContents.AnyAsync(cancellationToken))
+            return;
+
+        db.BranchOfficeContents.Add(new BranchOfficeContent
+        {
+            Address = "123 Main St"
+        });
+
+        await db.SaveChangesAsync(cancellationToken);
+    }
+
     public static async Task SeedDefaultUsersAsync(IServiceProvider services, string password, CancellationToken cancellationToken = default)
     {
         using var scope = services.CreateScope();

--- a/BlazorHybridApp/Program.cs
+++ b/BlazorHybridApp/Program.cs
@@ -65,6 +65,7 @@ using (var scope = app.Services.CreateScope())
         db.Database.EnsureCreated();
         DataSeeder.SeedBackgroundVideosAsync(scope.ServiceProvider).GetAwaiter().GetResult();
         DataSeeder.SeedHtmlContentsAsync(scope.ServiceProvider).GetAwaiter().GetResult();
+        DataSeeder.SeedBranchOfficeContentsAsync(scope.ServiceProvider).GetAwaiter().GetResult();
         DataSeeder.SeedDefaultUsersAsync(scope.ServiceProvider, defaultUserPassword).GetAwaiter().GetResult();
 }
 


### PR DESCRIPTION
## Summary
- add `BranchOfficeContent` model implementing `IContent`
- expose `BranchOfficeContents` via EF `ApplicationDbContext`
- seed an initial branch office in `DataSeeder`
- invoke the seeder from `Program`

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846e63cafa08322992911878392932a